### PR TITLE
[Cycode] Fix for IaC misconfiguration - The default namespace should not be used

### DIFF
--- a/distribution/kubernetes/vector-aggregator/statefulset.yaml
+++ b/distribution/kubernetes/vector-aggregator/statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/component: Aggregator
     app.kubernetes.io/version: "0.29.0-distroless-libc"
   annotations: {}
+  namespace: efs
 spec:
   replicas: 1
   podManagementPolicy: OrderedReady


### PR DESCRIPTION
[Cycode] Fix for IaC misconfiguration - The default namespace should not be used