### PR TITLE
[Cycode] Fix for vulnerable manifest file dependency - smallvec updated to version 1.6.1

### DIFF
--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -20,7 +20,7 @@ prost = { version = "0.11.8", default-features = false, features = ["std"] }
 regex = { version = "1.7.3", default-features = false, features = ["std", "perf"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false }
-smallvec = { version = "1", default-features = false, features = ["union"] }
+smallvec = { version = "^1.6.1", default-features = false, features = ["union"] }
 snafu = { version = "0.7.4", default-features = false, features = ["futures"] }
 syslog_loose = { version = "0.18", default-features = false, optional = true }
 tokio-util = { version = "0.7", default-features = false, features = ["codec"] }


### PR DESCRIPTION
# Cycode Vulnerable Dependencies Update 
This pull request updates the following manifest file:

| File Path | Number of packages to update |
|---|---|
| `lib/codecs/Cargo.toml` | 1 |

<details>
<summary><h3>:open_file_folder: lib/codecs/Cargo.toml</h3></summary>

1 package will be updated to resolve vulnerabilities:

| Package Name | Current Version | Updated Version | 
|---|---|---|
| `smallvec` | 1 | 1.6.1 |
</details>
